### PR TITLE
Docs: add .env.example and clarify README env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,10 @@
-# Django Configuration
-SECRET_KEY=your-secret-key-here
+# Generate Secret Key with: python -c "from django.core.management.utils import get_random_secret_key as g; print(g())"
+SECRET_KEY=
+# Set DEBUG to 'False' in production
 DEBUG=True
-
-# Supabase Database Configuration (Session Pooler)
-# Get this from: Supabase Dashboard → Your Project → Connect → Connection Info (Or check pinned message in Teams chat)
-DATABASE_URL=postgresql://postgres:your-password@aws-0-projectref.pooler.supabase.com:5432/postgres?sslmode=require
-
-# Instructions:
-# 1. Copy this file to .env
-# 2. Replace 'your-secret-key-here' with a Django secret key
-# 3. Replace 'your-password' with your Supabase database password
-# 4. Replace 'projectref' with your Supabase project reference
-# 5. Generate secret key: python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+# Comma-separated list of allowed hosts (e.g., localhost,127.0.0.1,yourdomain.com)
+ALLOWED_HOSTS=localhost,127.0.0.1
+# For Supabase PostgreSQL (DATABASE_URL=): Supabase Dashboard → Your Project → Connect → Connection String → Session Pooler
+# For Supabase PostgreSQL (DATABASE_URL=): Or check pinned message in Teams chat for Supabase key
+# Optional for PostgreSQL (leave empty to use SQLite locally for development)
+DATABASE_URL=

--- a/README.md
+++ b/README.md
@@ -30,13 +30,16 @@ venv\Scripts\activate
 pip install -r requirements.txt
 ```
 
-4) Configure environment (.env) (more detailed instruction in .env.example)
+4) Create (.env) file and then copy paste the content of (.env.example) there and follow instructions on configuration
 ```env
 # Generate Secret Key with: python -c "from django.core.management.utils import get_random_secret_key as g; print(g())"
 SECRET_KEY=
 # Set DEBUG to 'False' in production
 DEBUG=True
-# For Supabase PostgreSQL: Supabase Dashboard → Your Project → Connect → Connection String → Session Pooler (Or check pinned message in Teams chat for Supabase key)
+# Comma-separated list of allowed hosts (e.g., localhost,127.0.0.1,AgriLink.com)
+ALLOWED_HOSTS=localhost,127.0.0.1
+# For Supabase PostgreSQL (DATABASE_URL=): Supabase Dashboard → Your Project → Connect → Connection String → Session Pooler
+# For Supabase PostgreSQL (DATABASE_URL=): Or check pinned message in Teams chat for Supabase key
 # Optional for PostgreSQL (leave empty to use SQLite locally for development)
 DATABASE_URL=
 ```


### PR DESCRIPTION
- Add .env.example with SECRET_KEY, DEBUG, ALLOWED_HOSTS, and DATABASE_URL guidance
- Update README to align with .env.example and clarify setup instructions

This resolves previous merge issues around env config and provides a clear local/prod path.